### PR TITLE
add password-manager-service to plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -121,6 +121,7 @@ apps:
       - mount-observe
       - network
       - opengl
+      - password-manager-service
       - pulseaudio
       - unity7
       - wayland


### PR DESCRIPTION
This fixes #9 although ideally you'd want password-manager-service to auto-connect. I am not familiar with the process, but I understand someone would need to request that on the forums? 